### PR TITLE
feat(sysinfo): Enhance sysinfo to support fastfetch

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -8,8 +8,7 @@ WORKDIR /pagermaid/workdir
 
 COPY ./ /pagermaid/workdir
 
-RUN apk add --no-cache neofetch --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-    && apk add --no-cache git bash imagemagick libmagic curl tzdata libzbar figlet fortune openssl tini \
+RUN apk add --no-cache git bash imagemagick libmagic curl tzdata libzbar figlet fortune openssl tini fastfetch \
     && apk add --no-cache --update --virtual .build-deps gcc python3-dev musl-dev linux-headers rust cargo \
     && git config --global pull.ff only \
     && pip install -r requirements.txt \

--- a/languages/built-in/en.yml
+++ b/languages/built-in/en.yml
@@ -375,6 +375,7 @@ spn_deleted: deleted
 ## sysinfo
 sysinfo_des: Retrieve system information through neofetch.
 sysinfo_loading: Loading system information...
+sysinfo_not_found: Could not find fastfetch or neofetch, please install one of them.
 ## fortune
 fortune_des: read fortune cookies information.
 fortune_not_exist: Something went wrong, woooo~ There are no fortune cookies on this system

--- a/languages/built-in/en.yml
+++ b/languages/built-in/en.yml
@@ -373,7 +373,7 @@ del_BadRequestError: Something went wrong, woooo~ I don
 spn_deleted: deleted
 #status
 ## sysinfo
-sysinfo_des: Retrieve system information through neofetch.
+sysinfo_des: Retrieve system information through fastfetch (preferred) or neofetch.
 sysinfo_loading: Loading system information...
 sysinfo_not_found: Could not find fastfetch or neofetch, please install one of them.
 ## fortune

--- a/languages/built-in/ja.yml
+++ b/languages/built-in/ja.yml
@@ -375,6 +375,7 @@ spn_deleted: deleted
 ## sysinfo
 sysinfo_des: Retrieve system through neofetch.
 sysinfo_loading: Loading system information...
+sysinfo_not_found: fastfetch または neofetch が見つかりませんでした。いずれかをインストールしてください。
 ## fortune
 fortune_des: read fortune クッキーのフォーマットです。
 fortune_not_exist: Something went wrong, woo~ There are no fortune Cookieies on this system

--- a/languages/built-in/zh-cn.yml
+++ b/languages/built-in/zh-cn.yml
@@ -373,7 +373,7 @@ del_BadRequestError: 出错了呜呜呜 ~ 缺少删除此消息的权限。
 spn_deleted: 删除了
 #status
 ## sysinfo
-sysinfo_des: 通过 neofetch 检索系统信息.
+sysinfo_des: 通过 fastfetch（优先）或 neofetch 检索系统信息。
 sysinfo_loading: 加载系统信息中 . . .
 sysinfo_not_found: 未找到 fastfetch 或 neofetch, 请安装其中一个。
 ## fortune

--- a/languages/built-in/zh-cn.yml
+++ b/languages/built-in/zh-cn.yml
@@ -375,6 +375,7 @@ spn_deleted: 删除了
 ## sysinfo
 sysinfo_des: 通过 neofetch 检索系统信息.
 sysinfo_loading: 加载系统信息中 . . .
+sysinfo_not_found: 未找到 fastfetch 或 neofetch, 请安装其中一个。
 ## fortune
 fortune_des: 读取 fortune cookies 信息。
 fortune_not_exist: 出错了呜呜呜 ~ 此系统上没有 fortune cookies

--- a/languages/built-in/zh-tw.yml
+++ b/languages/built-in/zh-tw.yml
@@ -373,7 +373,7 @@ del_BadRequestError: Error！沒有權限。
 spn_deleted: 刪除了
 #status
 ## sysinfo
-sysinfo_des: 透過neofetch檢索系統資訊。
+sysinfo_des: 透過 fastfetch（若無則使用 neofetch）檢索系統資訊。
 sysinfo_loading: 正在載入系統資訊…
 sysinfo_not_found: 未找到 fastfetch 或 neofetch, 請安裝其中一個。
 ## fortune

--- a/languages/built-in/zh-tw.yml
+++ b/languages/built-in/zh-tw.yml
@@ -375,6 +375,7 @@ spn_deleted: 刪除了
 ## sysinfo
 sysinfo_des: 透過neofetch檢索系統資訊。
 sysinfo_loading: 正在載入系統資訊…
+sysinfo_not_found: 未找到 fastfetch 或 neofetch, 請安裝其中一個。
 ## fortune
 fortune_des: 讀取 Fortune Cookies資訊。
 fortune_not_exist: Error！系統沒有Fortune Cookies

--- a/pagermaid/modules/status.py
+++ b/pagermaid/modules/status.py
@@ -38,7 +38,9 @@ async def sysinfo(message: Message):
     if not Config.SILENT:
         message = await message.edit(lang("sysinfo_loading"))
     if which("fastfetch"):
-        result = await execute("fastfetch --config none --logo none --pipe --structure title:separator:os:kernel:uptime:loadavg:packages:initsystem:shell:locale:processes:memory:swap:disk:netio")
+        result = await execute(
+            "fastfetch --config none --logo none --pipe --structure title:separator:os:kernel:uptime:loadavg:packages:initsystem:shell:locale:processes:memory:swap:disk:netio"
+        )
     elif platform == "win32":
         return await message.edit(neofetch_win(), parse_mode="html")
     elif which("neofetch"):

--- a/pagermaid/modules/status.py
+++ b/pagermaid/modules/status.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime
 from getpass import getuser
 from platform import uname, python_version
-from shutil import disk_usage
+from shutil import disk_usage, which
 from socket import gethostname
 from subprocess import Popen, PIPE
 from sys import platform
@@ -34,12 +34,17 @@ DCs = {
 
 @listener(is_plugin=False, command="sysinfo", description=lang("sysinfo_des"))
 async def sysinfo(message: Message):
-    """Retrieve system information via neofetch."""
+    """Retrieve system information via fastfetch or neofetch."""
     if not Config.SILENT:
         message = await message.edit(lang("sysinfo_loading"))
-    if platform == "win32":
+    if which("fastfetch"):
+        result = await execute("fastfetch --config none --logo none --pipe --structure title:separator:os:kernel:uptime:loadavg:packages:initsystem:shell:locale:processes:memory:swap:disk:netio")
+    elif platform == "win32":
         return await message.edit(neofetch_win(), parse_mode="html")
-    result = await execute("neofetch --config none --stdout")
+    elif which("neofetch"):
+        result = await execute("neofetch --config none --stdout")
+    else:
+        result = lang("sysinfo_not_found")
     await message.edit(f"`{result}`")
     return None
 


### PR DESCRIPTION
The neofetch source code has been archived for over a year, and Debian 13 has also removed neofetch from its software repositories.

- Use `fastfetch` as the primary tool for system information retrieval in the `sysinfo` command, falling back to `neofetch` if `fastfetch` is not available.
- Added i18n support for the error message when neither `fastfetch` nor `neofetch` is found.
- Alpine container nolonger needs to install neofetch from testing repo.

<img width="398" height="309" alt="Telegram_pHOiSmvqUy" src="https://github.com/user-attachments/assets/8216124f-69a0-42b0-a8ef-5c470bd0c22f" />
