### PR TITLE
feat(account): Enhance profile command for channels and groups

### DIFF
--- a/languages/built-in/en.yml
+++ b/languages/built-in/en.yml
@@ -1,5 +1,5 @@
 ---
-#Chinese (Simplified)
+#English
 #main
 web_TypeError: Oops ~ Web interface is configured to bind to an invalid address.
 web_KeyError: Oops ~ Web interface configuration is missing in the config file.
@@ -67,20 +67,26 @@ profile_e_no: The specified user does not exist.
 profile_e_nou: The username specified does not exist.
 profile_e_nof: The UserID specified does not correspond to a user.
 profile_e_long: The UserID specified have exceeded the integer limit.
+profile_e_hidden: The UserID specified has hidden information.
 profile_user: User
 profile_noset: Not set.
 profile_nobio: Not set.
 profile_yes: "Yes"
 profile_no: "No"
 profile_name: Profile
+profile_entity_info: Entity Info
 profile_username: Username
-profile_fname: First name
-profile_lname: Last name
+profile_fname: First Name
+profile_lname: Last Name
+profile_title: Title
 profile_bio: Bio
-profile_gic: Group in common
+profile_gic: Groups in common
 profile_verified: Verified
 profile_restricted: Restricted
 profile_type: Type
+profile_channel: Channel
+profile_group: Group
+profile_members: Members
 ## block
 block_des: Block an user.
 block_process: Processing . . .

--- a/languages/built-in/ja.yml
+++ b/languages/built-in/ja.yml
@@ -1,5 +1,5 @@
 ---
-#Chinese (Simplified)
+#Japanese
 #main
 web_TypeError: Oops - Web interface is configured to bind to an invalid address。
 web_KeyError: Oops - Web interface configuration is mising in the config file。
@@ -67,20 +67,25 @@ profile_e_no: The specified user does not exist。
 profile_e_nou: ユーザー名 specified does not exist。
 profile_e_nof: ユーザーID specified does not correspond to a user.
 profile_e_long: UserID specified have exceeded integer limit。
+profile_e_hidden: 指定さたUserIDは情報を隠しました
 profile_user: ユーザー
-profile_noset: Not set.
-profile_nobio: Not set.
-profile_yes: "Yes"
-profile_no: "No"
-profile_name: プロファイル管理
-profile_username: ユーザ ID
-profile_fname: First name
-profile_lname: シェルター名
-profile_bio: ベオロ
-profile_gic: Group in common
-profile_verified: Verified
-profile_restricted: Restrict
-profile_type: Type
+profile_noset: Not set
+profile_nobio: 自己紹介がありません
+profile_yes: "はい"
+profile_no: "いいえ"
+profile_name: ユーザープロファイル
+profile_entity_info: エンティティ情報
+profile_username: ユーザー名
+profile_fname: 名
+profile_lname: 姓
+profile_title: タイトル
+profile_bio: 自己紹介
+profile_gic: 共通のグループ
+profile_verified: 認証み
+profile_restricted: 制限付き
+profile_type: タイプ
+profile_channel: チャンネル
+profile_group: グループ
 ## block
 block_des: ブロック･ユーザーです
 block_process: Processing.

--- a/languages/built-in/zh-cn.yml
+++ b/languages/built-in/zh-cn.yml
@@ -67,20 +67,26 @@ profile_e_no: 指定的用户不存在。
 profile_e_nou: 指定的道纹不存在。
 profile_e_nof: 无法通过此 UserID 找到对应的用户。
 profile_e_long: 指定的 UserID 已超出长度限制，您确定输对了？
+profile_e_hidden: 指定的 UserID 已隐藏信息
 profile_user: 用户
 profile_noset: 喵喵喵 ~ 好像没有设置
 profile_nobio: 没有公开的情报
 profile_yes: "是"
 profile_no: "否"
 profile_name: 用户简介
+profile_entity_info: 简介
 profile_username: 道纹
 profile_fname: 名字
 profile_lname: 姓氏
+profile_title: 名称
 profile_bio: 目前已知的情报
 profile_gic: 共同裙
 profile_verified: 官方认证
 profile_restricted: 受限制
 profile_type: 类型
+profile_channel: 频道
+profile_group: 群组
+profile_members: 成员数量
 ## block
 block_des: 拉黑一个用户
 block_process: 正在拉黑中 . . .

--- a/languages/built-in/zh-tw.yml
+++ b/languages/built-in/zh-tw.yml
@@ -1,5 +1,5 @@
 ---
-#Chinese (Simplified)
+#Chinese (Traditional)
 #main
 web_TypeError: Error！Web 介面綁定了一個無效網址。
 web_KeyError: Error！設定檔缺少Web介面配置。
@@ -67,20 +67,26 @@ profile_e_no: 指定的用戶不存在。
 profile_e_nou: 指定的用戶名不存在。
 profile_e_nof: 無法透過此UserID找到對應的用戶。
 profile_e_long: 指定的UserID已超出長度限制，錯了吧？
+profile_e_hidden: 指定的UserID已隱藏資料
 profile_user: 用戶
 profile_noset: 好像沒有設定OAO
 profile_nobio: 沒有公開的介紹
 profile_yes: "是"
 profile_no: "否"
 profile_name: 用戶介紹
+profile_entity_info: 簡介
 profile_username: 用戶名
 profile_fname: 名字
 profile_lname: 姓氏
-profile_bio: 用戶介紹
+profile_title: 稱號
+profile_bio: 目前已知的情報
 profile_gic: 共同的群組
 profile_verified: 官方認證
 profile_restricted: 受到限制
 profile_type: 類型
+profile_channel: 頻道
+profile_group: 群組
+profile_members: 成員數量
 ## block
 block_des: 拉黑一個用戶
 block_process: 正在拉黑中 . . .

--- a/pagermaid/modules/account.py
+++ b/pagermaid/modules/account.py
@@ -1,6 +1,5 @@
-"""This module contains utils to configure your account."""
-
 from os import remove
+from PIL import Image
 from telethon.errors import ImageProcessFailedError, PhotoCropSizeSmallError
 from telethon.errors.rpcerrorlist import (
     PhotoExtInvalidError,
@@ -17,15 +16,15 @@ from telethon.tl.functions.photos import (
     UploadProfilePhotoRequest,
 )
 from telethon.tl.functions.users import GetFullUserRequest
+from telethon.tl.functions.channels import GetFullChannelRequest
 from telethon.tl.functions.contacts import BlockRequest, UnblockRequest
 from telethon.tl.types import (
     InputPhoto,
     MessageMediaPhoto,
     MessageEntityMentionName,
-    MessageEntityPhone,
+    Channel,
     User,
 )
-from telethon.tl.types.users import UserFull
 
 from pagermaid.config import Config
 from pagermaid.enums import Message, Client
@@ -192,127 +191,132 @@ async def rmpfp(bot: Client, context: "Message"):
     is_plugin=False,
     command="profile",
     description=lang("profile_des"),
-    parameters="<username>",
+    parameters="<username / id>",
 )
 async def profile(context: "Message"):
-    """Queries profile of a user."""
-    if len(context.parameter) > 1:
-        await context.edit(f"{lang('error_prefix')}{lang('arg_error')}")
-        return
+    """Queries profile of a user, channel, or group."""
     if not Config.SILENT:
         await context.edit(lang("profile_process"))
+
+    target_entity = None
+    
     if context.reply_to_msg_id:
         reply_message = await context.get_reply_message()
-        if not reply_message:
-            return await context.edit(f"{lang('error_prefix')}{lang('arg_error')}")
-        user = reply_message.from_id
-        target_user = await context.client(GetFullUserRequest(user))
-    else:
-        if len(context.parameter) == 1:
-            user = context.parameter[0]
-            if user.isnumeric():
-                user = int(user)
-        else:
-            user_object = await context.client.get_me()
-            user = user_object.id
-        if context.message.entities is not None:
-            if isinstance(context.message.entities[0], MessageEntityMentionName):
-                user = context.message.entities[0].user_id
-            elif isinstance(context.message.entities[0], MessageEntityPhone):
-                user = int(context.parameter[0])
+        if reply_message:
+            if reply_message.fwd_from:
+                if reply_message.fwd_from.from_id:
+                    target_entity = await context.client.get_entity(reply_message.fwd_from.from_id)
+                else:
+                    await context.edit(f"{lang('error_prefix')}{lang('profile_e_hidden')}")
+                    return
             else:
-                await context.edit(f"{lang('error_prefix')}{lang('arg_error')}")
-                return
+                target_entity = await reply_message.get_sender()
+    elif context.parameter:
+        user_input = context.parameter[0]
+        if user_input.isnumeric() or user_input.startswith("-100"):
+            try: user_input = int(user_input)
+            except ValueError: pass 
         try:
-            user_object = await context.client.get_entity(user)
-            target_users: UserFull = await context.client(
-                GetFullUserRequest(user_object.id)
-            )
-            target_user = target_users.users[0]
-        except (TypeError, ValueError, OverflowError) as exception:
-            if str(exception).startswith("Cannot find any entity corresponding to"):
-                await context.edit(f"{lang('error_prefix')}{lang('profile_e_no')}")
-                return
-            if str(exception).startswith("No user has"):
-                await context.edit(f"{lang('error_prefix')}{lang('profile_e_nou')}")
-                return
-            if str(exception).startswith("Could not find the input entity for"):
-                await context.edit(f"{lang('error_prefix')}{lang('profile_e_nof')}")
-                return
-            if isinstance(exception, OverflowError):
-                await context.edit(f"{lang('error_prefix')}{lang('profile_e_long')}")
-                return
-            raise exception
-    user_type = "Bot" if target_user.bot else lang("profile_user")
-    username_system = (
-        f"@{target_user.username}"
-        if target_user.username is not None
-        else (lang("profile_noset"))
-    )
-    if not target_user.first_name:
+            target_entity = await context.client.get_entity(user_input)
+        except (TypeError, ValueError, OverflowError):
+            await context.edit(f"{lang('error_prefix')}{lang('arg_error')}")
+            return
+    else:
+        target_entity = await context.client.get_me()
+
+    if not target_entity:
         await context.edit(f"{lang('error_prefix')}{lang('profile_e_no')}")
         return
-    first_name = target_user.first_name.replace("\u2060", "")
-    last_name = (
-        target_user.last_name.replace("\u2060", "")
-        if target_user.last_name is not None
-        else (lang("profile_noset"))
-    )
-    biography = (
-        target_user.about if hasattr(target_user, "about") else lang("profile_nobio")
-    )
-    verified = lang("profile_yes") if target_user.verified else lang("profile_no")
-    restricted = lang("profile_yes") if target_user.restricted else lang("profile_no")
-    common_chats_count = (
-        target_user.common_chats_count
-        if hasattr(target_user, "common_chats_count")
-        else 0
-    )
-    caption = (
-        f"**{lang('profile_name')}:** \n"
-        f"{lang('profile_username')}: {username_system} \n"
-        f"ID: {target_user.id} \n"
-        f"{lang('profile_fname')}: {first_name} \n"
-        f"{lang('profile_lname')}: {last_name} \n"
-        f"{lang('profile_bio')}: {biography} \n"
-        f"{lang('profile_gic')}: {common_chats_count} \n"
-        f"{lang('profile_verified')}: {verified} \n"
-        f"{lang('profile_restricted')}: {restricted} \n"
-        f"{lang('profile_type')}: {user_type} \n"
-        f"[{first_name}](tg://user?id={target_user.id})"
-    )
-    photo = await context.client.download_profile_photo(
-        target_user.id, "./" + str(target_user.id) + ".jpg", download_big=True
-    )
-    try:
-        reply_to = context.message.reply_to_msg_id
-        try:
-            await context.client.send_file(
-                context.chat_id,
-                photo,
-                caption=caption,
-                link_preview=False,
-                force_document=False,
-                reply_to=reply_to,
-            )
-            await context.delete()
-        except TypeError:
-            await context.edit(caption)
-    except:
-        try:
-            await context.client.send_file(
-                context.chat_id,
-                photo,
-                caption=caption,
-                link_preview=False,
-                force_document=False,
-            )
-            await context.delete()
-        except TypeError:
-            await context.edit(caption)
-    finally:
-        safe_remove(photo)
 
+    caption = ""
+    photo_path = f"./{target_entity.id}.jpg"
+
+    if isinstance(target_entity, User):
+        try:
+            full_info = await context.client(GetFullUserRequest(target_entity))
+            target_user = full_info.users[0]
+            target_user_full = full_info.full_user
+
+            user_type = "Bot" if target_user.bot else lang("profile_user")
+            username_system = f"@{target_user.username}" if target_user.username else lang("profile_noset")
+            first_name = target_user.first_name.replace("\u2060", "") if target_user.first_name else ""
+            last_name = target_user.last_name.replace("\u2060", "") if target_user.last_name else lang("profile_noset")
+            biography = target_user_full.about if target_user_full.about else lang("profile_nobio")
+            common_chats_count = target_user_full.common_chats_count
+            verified = lang("profile_yes") if target_user.verified else lang("profile_no")
+            restricted = lang("profile_yes") if target_user.restricted else lang("profile_no")
+            
+            caption = (
+                f"**👤 {lang('profile_name')}:**\n"
+                f"**{lang('profile_username')}:** {username_system}\n"
+                f"**ID:** `{target_user.id}`\n"
+                f"**{lang('profile_fname')}:** [{first_name}](tg://user?id={target_user.id})\n"
+                f"**{lang('profile_lname')}:** {last_name}\n"
+                f"**{lang('profile_bio')}:** {biography}\n"
+                f"**{lang('profile_gic')}:** {common_chats_count}\n"
+                f"**{lang('profile_verified')}:** {verified}\n"
+                f"**{lang('profile_restricted')}:** {restricted}\n"
+                f"**{lang('profile_type')}:** {user_type}\n"
+            )
+        except (TypeError, ValueError):
+            return await context.edit(f"{lang('error_prefix')}{lang('profile_e_no')}")
+
+    elif isinstance(target_entity, Channel):
+        try:
+            full_info = await context.client(GetFullChannelRequest(channel=target_entity))
+            channel = full_info.chats[0]
+            channel_full = full_info.full_chat
+
+            entity_type = lang("profile_channel") if not channel.megagroup else lang("profile_group")
+            username_system = f"@{channel.username}" if channel.username else lang("profile_noset")
+            description = channel_full.about if channel_full.about else lang("profile_noset")
+            members_count = channel_full.participants_count
+            verified = lang("profile_yes") if channel.verified else lang("profile_no")
+            restricted = lang("profile_yes") if channel.restricted else lang("profile_no")
+
+            caption = (
+                f"**🏢 {lang('profile_entity_info')}:**\n"
+                f"**{lang('profile_username')}:** {username_system}\n"
+                f"**ID:** `{channel.id}`\n"
+                f"**{lang('profile_title')}:** {channel.title}\n"
+                f"**{lang('profile_type')}:** {entity_type}\n"
+                f"**{lang('profile_bio')}:** {description}\n"
+                f"**{lang('profile_members')}:** {members_count}\n"
+                f"**{lang('profile_verified')}:** {verified}\n"
+                f"**{lang('profile_restricted')}:** {restricted}"
+            )
+        except (TypeError, ValueError):
+            return await context.edit(f"{lang('error_prefix')}{lang('profile_e_no')}")
+
+    else:
+        return await context.edit(f"{lang('error_prefix')}{lang('profile_e_unsupported')}")
+
+    downloaded_photo = None
+    try:
+        downloaded_photo = await context.client.download_profile_photo(
+            target_entity, file=photo_path, download_big=True
+        )
+        if downloaded_photo:
+            try:
+                TARGET_WIDTH = 300
+                img = Image.open(photo_path)
+                if img.width > TARGET_WIDTH:
+                    aspect_ratio = img.height / img.width
+                    new_height = int(TARGET_WIDTH * aspect_ratio)
+                    resized_img = img.resize((TARGET_WIDTH, new_height), Image.Resampling.BICUBIC)
+                    resized_img.save(photo_path)
+            except Exception: pass
+        
+        await context.client.send_file(
+            context.chat_id, photo_path, caption=caption, link_preview=False,
+            reply_to=context.message.reply_to_msg_id
+        )
+        await context.delete()
+    except Exception:
+        await context.edit(caption, link_preview=False)
+    finally:
+        if downloaded_photo:
+            safe_remove(photo_path)
 
 @listener(
     is_plugin=False,


### PR DESCRIPTION
This commit expands the functionality of the `profile` command to retrieve and display information for channels and groups, in addition to users.

- Fix some bugs in User info display.(common groups, bio, etc.)
- Resize Profile Pic to 300 pixels wide, so it won't get too big on desktop client.
- The command now shows entity-specific details like title and member count.
- Adds a new error message for entities with hidden information.
- Updates translations in en, ja, zh-cn, and zh-tw to support the new fields and messages.
- Corrects the language name comments in the built-in language files.

## Summary by Sourcery

Enhance the profile command to fetch and display details for user, channel, and group entities; include improved error handling, photo resizing, and updated multilingual translations

New Features:
- Extend profile command to support channels and groups with their title, type, and member count
- Add new error message for entities with hidden information

Bug Fixes:
- Fix display issues in user info (common groups count, biography, etc.)

Enhancements:
- Resize downloaded profile pictures to a maximum width of 300 pixels
- Refactor profile command logic for unified entity retrieval and processing

Documentation:
- Update and correct translations in English, Japanese, Simplified Chinese, and Traditional Chinese for new fields and messages