### PR TITLE
Fix(system): sh command output

### DIFF
--- a/pagermaid/modules/system.py
+++ b/pagermaid/modules/system.py
@@ -45,7 +45,7 @@ async def sh(message: "Message"):
         return
 
     message = await message.edit(
-        f"`{user}`@{hostname} ~\n> `$` {command}", parse_mode="html"
+        f"`{user}`@{hostname} ~\n> `$` {command}", parse_mode="md"
     )
 
     result = await execute(command)
@@ -56,16 +56,16 @@ async def sh(message: "Message"):
             if Config.USE_PB:
                 url = await paste_pb(result)
                 if url:
-                    final_result = html.escape(f"{url}/bash")
+                    final_result = f"{url}/bash"
         else:
-            final_result = f"<code>{html.escape(result)}</code>"
+            final_result = result
 
         if (len(result) > 3072 and not Config.USE_PB) or final_result is None:
             await attach_log(result, message.chat_id, "output.log", message.id)
             return
         await message.edit(
-            f"`{user}`@{hostname} ~\n> `#` {command}\n\n{final_result}",
-            parse_mode="html",
+            f"`{user}`@{hostname} ~\n> `#` {command}\n\n`{final_result}`",
+            parse_mode="md",
         )
     else:
         return

--- a/pagermaid/modules/system.py
+++ b/pagermaid/modules/system.py
@@ -64,7 +64,7 @@ async def sh(message: "Message"):
             await attach_log(result, message.chat_id, "output.log", message.id)
             return
         await message.edit(
-            f"`{user}`@{hostname} ~\n> `#` {command}\n\n`{final_result}`",
+            f"`{user}`@{hostname} ~\n> `#` {command}\n\n```\n{final_result}\n```",
             parse_mode="md",
         )
     else:

--- a/pagermaid/modules/system.py
+++ b/pagermaid/modules/system.py
@@ -44,9 +44,7 @@ async def sh(message: "Message"):
         await message.edit(lang("arg_error"))
         return
 
-    message = await message.edit(
-        f"`{user}`@{hostname} ~\n> `$` {command}", parse_mode="md"
-    )
+    message = await message.edit(f"`{user}`@{hostname} ~\n> `$` {command}")
 
     result = await execute(command)
 
@@ -56,17 +54,14 @@ async def sh(message: "Message"):
             if Config.USE_PB:
                 url = await paste_pb(result)
                 if url:
-                    final_result = f"{url}/bash"
+                    final_result = html.escape(f"{url}/bash")
         else:
-            final_result = result
+            final_result = f"<code>{html.escape(result)}</code>"
 
         if (len(result) > 3072 and not Config.USE_PB) or final_result is None:
             await attach_log(result, message.chat_id, "output.log", message.id)
             return
-        await message.edit(
-            f"`{user}`@{hostname} ~\n> `#` {command}\n\n```\n{final_result}\n```",
-            parse_mode="md",
-        )
+        await message.edit(f"`{user}`@{hostname} ~\n> `#` {command}\n\n{final_result}")
     else:
         return
 


### PR DESCRIPTION
Change the parse mode for the sh command from HTML to Markdown.

## Summary by Sourcery

Switch the sh command to use Markdown formatting instead of HTML and remove HTML escaping of output

Bug Fixes:
- Change sh command message parse_mode from HTML to Markdown
- Remove HTML-escaping of command output and pasted URL
- Wrap command output in Markdown code backticks instead of HTML <code> tags