### PR TITLE
refactor: drop ImageMagick dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN source ~/.bashrc \
         curl \
         wget \
         neofetch \
-        imagemagick \
         ffmpeg \
         fortune-mod \
         figlet \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -8,7 +8,7 @@ WORKDIR /pagermaid/workdir
 
 COPY ./ /pagermaid/workdir
 
-RUN apk add --no-cache git bash imagemagick libmagic curl tzdata libzbar figlet fortune openssl tini fastfetch \
+RUN apk add --no-cache git bash libmagic curl tzdata libzbar figlet fortune openssl tini fastfetch \
     && apk add --no-cache --update --virtual .build-deps gcc python3-dev musl-dev linux-headers rust cargo \
     && git config --global pull.ff only \
     && pip install -r requirements.txt \


### PR DESCRIPTION
It seems that only fbcon command needed ImageMagick, and fbcon command is not in codebase now.

The rest of plugins which need to process image rely on pillow.

## Summary by Sourcery

Remove ImageMagick from container builds since the fbcon command is no longer present and image processing is handled by pillow.

Build:
- Drop the imagemagick package from Dockerfile
- Remove the imagemagick package from Dockerfile.alpine