### PR TITLE
feat(apt): Add list command to display all remote plugins with status 

### DIFF
--- a/languages/built-in/en.yml
+++ b/languages/built-in/en.yml
@@ -326,10 +326,12 @@ apt_not_exist: Something went wrong ~ The specified plug-in does not exist.
 apt_no_running_plugins: There are no running plugins.
 apt_no_load_failed_plugins: No failed plugins loaded
 apt_no_disabled_plugins: Plugins that are not disabled
-apt_plugin_list: plug-in list
+apt_plugin_list: Plug-in list
+apt_plugin_list_des: "\nUse `-apt list <page>` to view a specific page."
 apt_plugin_running: running
 apt_plugin_disabled: disabled
 apt_plugin_failed: failed to load
+apt_plugin_not_installed: not installed
 apt_enable: enabled
 apt_disable: disabled
 apt_uploading: uploading plugin...

--- a/languages/built-in/en.yml
+++ b/languages/built-in/en.yml
@@ -327,7 +327,7 @@ apt_no_running_plugins: There are no running plugins.
 apt_no_load_failed_plugins: No failed plugins loaded
 apt_no_disabled_plugins: Plugins that are not disabled
 apt_plugin_list: Plug-in list
-apt_plugin_list_des: "\nUse `-apt list <page>` to view a specific page."
+apt_plugin_list_des: "Use `-apt list <page>` to view a specific page."
 apt_plugin_running: running
 apt_plugin_disabled: disabled
 apt_plugin_failed: failed to load

--- a/languages/built-in/ja.yml
+++ b/languages/built-in/ja.yml
@@ -326,7 +326,7 @@ apt_no_running_plugins: There are no running plugins.
 apt_no_load_failed_plugins: No failed plugins loaded
 apt_no_disabled_plugins: Plugins that are not disabled
 apt_plugin_list: Plug-in list
-apt_plugin_list_des: "\n`-apt list <ページ番号>` を使用して指定ページへ移動します。"
+apt_plugin_list_des: "`-apt list <ページ番号>` を使用して指定ページへ移動します。"
 apt_plugin_running: running
 apt_plugin_disabled: disabled
 apt_plugin_failed: failed to load

--- a/languages/built-in/ja.yml
+++ b/languages/built-in/ja.yml
@@ -325,10 +325,12 @@ apt_not_exist: Something went wrong - The specified plug-in does not exist.
 apt_no_running_plugins: There are no running plugins.
 apt_no_load_failed_plugins: No failed plugins loaded
 apt_no_disabled_plugins: Plugins that are not disabled
-apt_plugin_list: plug-in list
+apt_plugin_list: Plug-in list
+apt_plugin_list_des: "\n`-apt list <ページ番号>` を使用して指定ページへ移動します。"
 apt_plugin_running: running
 apt_plugin_disabled: disabled
 apt_plugin_failed: failed to load
+apt_plugin_not_installed: 未インストール
 apt_enable: enabled
 apt_disable: disabled
 apt_uploading: uploading plugin...

--- a/languages/built-in/zh-cn.yml
+++ b/languages/built-in/zh-cn.yml
@@ -327,7 +327,7 @@ apt_no_running_plugins: 没有运行中的插件
 apt_no_load_failed_plugins: 没有加载失败的插件
 apt_no_disabled_plugins: 没有关闭的插件
 apt_plugin_list: 插件列表
-apt_plugin_list_des: "\n使用 `-apt list <页码>` 跳转指定页。"
+apt_plugin_list_des: "使用 `-apt list <页码>` 跳转指定页。"
 apt_plugin_running: 运行中
 apt_plugin_disabled: 已关闭
 apt_plugin_failed: 加载失败

--- a/languages/built-in/zh-cn.yml
+++ b/languages/built-in/zh-cn.yml
@@ -327,9 +327,11 @@ apt_no_running_plugins: 没有运行中的插件
 apt_no_load_failed_plugins: 没有加载失败的插件
 apt_no_disabled_plugins: 没有关闭的插件
 apt_plugin_list: 插件列表
+apt_plugin_list_des: "\n使用 `-apt list <页码>` 跳转指定页。"
 apt_plugin_running: 运行中
 apt_plugin_disabled: 已关闭
 apt_plugin_failed: 加载失败
+apt_plugin_not_installed: 未安装
 apt_enable: 已启用
 apt_disable: 已禁用
 apt_uploading: 上传插件中 . . .

--- a/languages/built-in/zh-tw.yml
+++ b/languages/built-in/zh-tw.yml
@@ -327,9 +327,11 @@ apt_no_running_plugins: 沒有執行中的插件。
 apt_no_load_failed_plugins: 沒有加載失敗的插件
 apt_no_disabled_plugins: 沒有關閉的插件。
 apt_plugin_list: 插件列表
+apt_plugin_list_des: "\n使用 `-apt list <頁碼>` 跳至指定頁面。"
 apt_plugin_running: 執行中
 apt_plugin_disabled: 已關閉
 apt_plugin_failed: 載入失敗
+apt_plugin_not_installed: 未安裝
 apt_enable: 已啟用
 apt_disable: 已禁用
 apt_uploading: 上傳插件中…

--- a/languages/built-in/zh-tw.yml
+++ b/languages/built-in/zh-tw.yml
@@ -327,7 +327,7 @@ apt_no_running_plugins: 沒有執行中的插件。
 apt_no_load_failed_plugins: 沒有加載失敗的插件
 apt_no_disabled_plugins: 沒有關閉的插件。
 apt_plugin_list: 插件列表
-apt_plugin_list_des: "\n使用 `-apt list <頁碼>` 跳至指定頁面。"
+apt_plugin_list_des: "使用 `-apt list <頁碼>` 跳至指定頁面。"
 apt_plugin_running: 執行中
 apt_plugin_disabled: 已關閉
 apt_plugin_failed: 載入失敗

--- a/pagermaid/modules/plugin.py
+++ b/pagermaid/modules/plugin.py
@@ -264,6 +264,54 @@ async def plugin(message: Message):
                 await message.edit(lang("apt_search_not_found"))
             else:
                 await message.edit(search_result, parse_mode="md")
+    elif message.parameter[0] == "list":
+        await plugin_manager.load_remote_plugins()
+        plugins = sorted(plugin_manager.remote_plugins, key=lambda x: x.name)
+
+        if not plugins:
+            await message.edit("No remote plugins found.")
+            return
+
+        active, disabled, inactive = plugin_manager.get_plugins_status()
+        active_set = set(active)
+        disabled_set = set(p.name for p in disabled)
+        inactive_set = set(p.name for p in inactive)
+
+        page = 1
+        if len(message.parameter) > 1:
+            if message.parameter[1].isdigit():
+                page = int(message.parameter[1])
+            else:
+                await message.edit(lang("arg_error"))
+                return
+
+        page_size = 15
+        total_pages = (len(plugins) + page_size - 1) // page_size
+
+        if not 1 <= page <= total_pages:
+            page = 1
+
+        start_index = (page - 1) * page_size
+        end_index = start_index + page_size
+        
+        plugins_to_show = plugins[start_index:end_index]
+        
+        text = f"**Plugin List ({page}/{total_pages})**\n\n"
+        text = f"**{lang('apt_plugin_list')} ({page}/{total_pages})**\n\n"
+        for plugin in plugins_to_show:
+            status_icon = '⚪️'
+            if plugin.name in active_set:
+                status_icon = '🟢'
+            elif plugin.name in disabled_set:
+                status_icon = '🔘'
+            elif plugin.name in inactive_set:
+                status_icon = '🔴'
+            
+            text += f"{status_icon} `{plugin.name}`\n  `·` {plugin.des_short}\n"
+        
+        text += f"\n🟢: {lang('apt_plugin_running')}, 🔘: {lang('apt_disable')},  🔴: {lang('apt_plugin_failed')}, ⚪️: {lang('apt_plugin_not_installed')}.\n"
+        text += f"{lang('apt_plugin_list_des')}"
+        await message.edit(text, parse_mode="md")
     elif message.parameter[0] == "export":
         if not exists(f"{plugin_directory}version.json"):
             await message.edit(lang("apt_why_not_install_a_plugin"))

--- a/pagermaid/modules/plugin.py
+++ b/pagermaid/modules/plugin.py
@@ -274,8 +274,8 @@ async def plugin(message: Message):
 
         active, disabled, inactive = plugin_manager.get_plugins_status()
         active_set = set(active)
-        disabled_set = set(p.name for p in disabled)
-        inactive_set = set(p.name for p in inactive)
+        inactive_set = set(p.name for p in disabled)
+        disabled_set = set(p.name for p in inactive)
 
         page = 1
         if len(message.parameter) > 1:

--- a/pagermaid/modules/plugin.py
+++ b/pagermaid/modules/plugin.py
@@ -296,7 +296,6 @@ async def plugin(message: Message):
         
         plugins_to_show = plugins[start_index:end_index]
         
-        text = f"**Plugin List ({page}/{total_pages})**\n\n"
         text = f"**{lang('apt_plugin_list')} ({page}/{total_pages})**\n\n"
         for plugin in plugins_to_show:
             status_icon = '⚪️'

--- a/pagermaid/modules/plugin.py
+++ b/pagermaid/modules/plugin.py
@@ -269,7 +269,7 @@ async def plugin(message: Message):
         plugins = sorted(plugin_manager.remote_plugins, key=lambda x: x.name)
 
         if not plugins:
-            await message.edit("No remote plugins found.")
+            await message.edit(lang("apt_search_not_found"))
             return
 
         active, disabled, inactive = plugin_manager.get_plugins_status()
@@ -279,9 +279,9 @@ async def plugin(message: Message):
 
         page = 1
         if len(message.parameter) > 1:
-            if message.parameter[1].isdigit():
+            try:
                 page = int(message.parameter[1])
-            else:
+            except ValueError:
                 await message.edit(lang("arg_error"))
                 return
 
@@ -293,24 +293,24 @@ async def plugin(message: Message):
 
         start_index = (page - 1) * page_size
         end_index = start_index + page_size
-        
+
         plugins_to_show = plugins[start_index:end_index]
-        
-        text = f"**{lang('apt_plugin_list')} ({page}/{total_pages})**\n\n"
-        for plugin in plugins_to_show:
-            status_icon = '⚪️'
-            if plugin.name in active_set:
-                status_icon = '🟢'
-            elif plugin.name in disabled_set:
-                status_icon = '🔘'
-            elif plugin.name in inactive_set:
-                status_icon = '🔴'
-            
-            text += f"{status_icon} `{plugin.name}`\n  `·` {plugin.des_short}\n"
-        
+
+        text = f"**{lang('apt_plugin_list')} ({page}/{total_pages})**\n\n<blockquote expandable>"
+        for p in plugins_to_show:
+            status_icon = "⚪️"
+            if p.name in active_set:
+                status_icon = "🟢"
+            elif p.name in disabled_set:
+                status_icon = "🔘"
+            elif p.name in inactive_set:
+                status_icon = "🔴"
+
+            text += f"{status_icon} `{p.name}`\n  `·` {p.des_short}\n"
+
         text += f"\n🟢: {lang('apt_plugin_running')}, 🔘: {lang('apt_disable')},  🔴: {lang('apt_plugin_failed')}, ⚪️: {lang('apt_plugin_not_installed')}.\n"
-        text += f"{lang('apt_plugin_list_des')}"
-        await message.edit(text, parse_mode="md")
+        text += f"</blockquote>\n{lang('apt_plugin_list_des')}"
+        await message.edit(text)
     elif message.parameter[0] == "export":
         if not exists(f"{plugin_directory}version.json"):
             await message.edit(lang("apt_why_not_install_a_plugin"))


### PR DESCRIPTION
This commit introduces the `-apt list` command, which provides a comprehensive and paginated view of all available remote plugins.

The list indicates the status of each plugin using an icon:
- 🟢 Running
- 🔘 Disabled
- 🔴 Failed to load
- ⚪️ Not installed

Pagination is supported via `-apt list <page>` to handle a large number of plugins.

## Summary by Sourcery

Introduce the `-apt list` feature to show a paginated, status-marked list of remote plugins and add necessary translation strings across supported languages

New Features:
- Add `-apt list` command to display all remote plugins with status icons and pagination support

Documentation:
- Add localization entries for `apt_plugin_list_des` and `apt_plugin_not_installed` in English, Japanese, Simplified Chinese, and Traditional Chinese