### PR TITLE
chore(Dockerfile): remove cargo directory after build to save space

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,6 +13,7 @@ RUN apk add --no-cache git bash libmagic curl tzdata libzbar figlet fortune open
     && git config --global pull.ff only \
     && pip install -r requirements.txt \
     && pip cache purge \
+    && rm -rf /root/.cargo \
     && apk del .build-deps
 
 ENTRYPOINT ["tini","--","bash","utils/docker-config.sh"]


### PR DESCRIPTION
如题。

## Summary by Sourcery

No effective changes are present in this pull request’s diff for Dockerfile.alpine; the file remains unchanged.