### PR TITLE
feat: prefer uv for Python dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:latest AS uv
+FROM astral-sh/uv:0.11 AS uv
 
 FROM ubuntu:jammy
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM ghcr.io/astral-sh/uv:latest AS uv
+
 FROM ubuntu:jammy
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     LANG=zh_CN.UTF-8 \
@@ -7,6 +9,7 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]
 WORKDIR /pagermaid/workdir
+COPY --from=uv /uv /usr/local/bin/uv
 RUN source ~/.bashrc \
     ## 安装运行环境依赖，自编译建议修改为国内镜像源
 #   && sed -i 's/archive.ubuntu.com/mirrors.bfsu.edu.cn/g' /etc/apt/sources.list \
@@ -67,9 +70,8 @@ RUN source ~/.bashrc \
     && echo "Asia/Shanghai" > /etc/timezone \
     ## python软链接
     && ln -sf /usr/bin/python3 /usr/bin/python \
-    ## 升级pip
+    ## 配置 pip
 #   && pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple \
-    && python -m pip install --upgrade pip \
     ## 添加用户
     && echo "pagermaid ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/pagermaid \
     && useradd pagermaid -r -m -d /pagermaid -s /bin/bash \
@@ -77,8 +79,8 @@ RUN source ~/.bashrc \
     ## 克隆仓库
     && git clone -b master https://github.com/TeamPGM/PagerMaid-Modify.git /pagermaid/workdir \
     && git config --global pull.ff only \
-    ## pip install
-    && pip install -r requirements.txt \
+    ## install Python dependencies
+    && uv pip install --system -r requirements.txt \
     ## 卸载编译依赖，清理安装缓存
     && sudo apt-get purge --auto-remove -y \
         build-essential \
@@ -104,7 +106,7 @@ RUN source ~/.bashrc \
         pkg-config \
     && apt-get clean -y \
     && rm -rf \
-        ## 删除apt和pip的安装缓存
+        ## 删除apt和Python安装缓存
         /tmp/* \
         /var/lib/apt/lists/* \
         /var/tmp/* \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,3 +1,5 @@
+FROM ghcr.io/astral-sh/uv:latest AS uv
+
 FROM python:alpine
 
 ENV PAGERMAID_DIR=/pagermaid
@@ -6,13 +8,14 @@ ENV SHELL=/bin/bash
 
 WORKDIR /pagermaid/workdir
 
+COPY --from=uv /uv /usr/local/bin/uv
 COPY ./ /pagermaid/workdir
 
 RUN apk add --no-cache git bash libmagic curl tzdata libzbar figlet fortune openssl tini fastfetch \
     && apk add --no-cache --update --virtual .build-deps gcc python3-dev musl-dev linux-headers rust cargo \
     && git config --global pull.ff only \
-    && pip install -r requirements.txt \
-    && pip cache purge \
+    && uv pip install --system -r requirements.txt \
+    && uv cache clean \
     && rm -rf /root/.cargo \
     && apk del .build-deps
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:latest AS uv
+FROM astral-sh/uv:0.11 AS uv
 
 FROM python:alpine
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Pagermaid 是一个用在 Telegram 的实用工具。
 获得 `API_ID` 和 `API_HASH` 后，你可以通过下面两种方式获取 `SESSION`：
 
 * 在线获取：[![Repl.it](https://replit.com/badge/github/TeamPGM/PagerMaid-Modify)](https://replit.com/@mrwangzhe/gensession)
-* 本地获取：`cd utils && python3 -m pip install telethon && python3 gensession.py`
+* 本地获取：`cd utils && python3 gensession.py`，脚本会优先使用 `uv` 安装 Telethon，未安装 `uv` 时回退到 `pip`
 
 # 对存在使用本项目用户群组的提醒
 

--- a/pagermaid/common/update.py
+++ b/pagermaid/common/update.py
@@ -1,6 +1,4 @@
-from sys import executable
-
-from pagermaid.utils import execute
+from pagermaid.utils import execute, package_install_shell_command
 
 
 async def update(force: bool = False):
@@ -8,5 +6,7 @@ async def update(force: bool = False):
     if force:
         await execute("git reset --hard origin/master")
     await execute("git pull --all")
-    await execute(f"{executable} -m pip install --upgrade -r requirements.txt")
-    await execute(f"{executable} -m pip install -r requirements.txt")
+    await execute(
+        package_install_shell_command(["--upgrade", "-r", "requirements.txt"])
+    )
+    await execute(package_install_shell_command(["-r", "requirements.txt"]))

--- a/pagermaid/utils/__init__.py
+++ b/pagermaid/utils/__init__.py
@@ -1,6 +1,7 @@
 from ._config_utils import *
 from ._eval import *
 from ._log import *
+from ._package import *
 from ._path import *
 from ._session_manager import *
 from ._sub import *

--- a/pagermaid/utils/_eval.py
+++ b/pagermaid/utils/_eval.py
@@ -1,5 +1,4 @@
 import contextlib
-import subprocess
 import os
 import shlex
 
@@ -8,6 +7,8 @@ from sys import executable
 from asyncio import create_subprocess_shell
 from asyncio.subprocess import PIPE
 from typing import Optional
+
+from pagermaid.utils._package import install_package
 
 try:
     import pwd
@@ -55,7 +56,7 @@ def pip_install(
         # when import name is not provided, use package name
         alias = package
     if find_spec(alias) is None:
-        subprocess.call([executable, "-m", "pip", "install", f"{package}{version}"])
+        install_package([f"{package}{version}"], executable)
         if find_spec(package) is None:
             return False
     return True

--- a/pagermaid/utils/_package.py
+++ b/pagermaid/utils/_package.py
@@ -1,0 +1,21 @@
+import shlex
+import shutil
+import subprocess
+from sys import executable
+from typing import Iterable, List
+
+
+def package_install_command(args: Iterable[str], python: str = executable) -> List[str]:
+    """Build a package install command, preferring uv when available."""
+    args = list(args)
+    if shutil.which("uv"):
+        return ["uv", "pip", "install", "--python", python, *args]
+    return [python, "-m", "pip", "install", *args]
+
+
+def package_install_shell_command(args: Iterable[str], python: str = executable) -> str:
+    return " ".join(shlex.quote(part) for part in package_install_command(args, python))
+
+
+def install_package(args: Iterable[str], python: str = executable) -> int:
+    return subprocess.call(package_install_command(args, python))

--- a/pagermaid/utils/_package.py
+++ b/pagermaid/utils/_package.py
@@ -18,4 +18,9 @@ def package_install_shell_command(args: Iterable[str], python: str = executable)
 
 
 def install_package(args: Iterable[str], python: str = executable) -> int:
-    return subprocess.call(package_install_command(args, python))
+    command = package_install_command(args, python)
+    try:
+        subprocess.check_call(command)  # nosec B603 - command is built from a controlled allow-list
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode or 1
+    return 0

--- a/utils/docker.md
+++ b/utils/docker.md
@@ -1,6 +1,6 @@
 ## 特点
 
-- 容器在启动或重启时，将自动更新脚本并安装pip依赖。
+- 容器在启动或重启时，将自动更新脚本并安装 Python 依赖。
 
 - 包括redis缓存数据和插件在内，全部数据支持数据持久化，更新镜像或重建容器数据不丢失。
 
@@ -34,4 +34,3 @@ cp docker-compose.gen.yml docker-compose.yml
 4. 启动容器`docker-compose up -d`。
 
 5. 运行`docker exec -it pagermaid bash utils/docker-config.sh`进行配置。
-

--- a/utils/gensession.py
+++ b/utils/gensession.py
@@ -1,5 +1,13 @@
-import os
+import shutil
+import subprocess
 from sys import executable
+
+
+def install_package(package: str):
+    if shutil.which("uv"):
+        subprocess.call(["uv", "pip", "install", "--python", executable, package])
+    else:
+        subprocess.call([executable, "-m", "pip", "install", package])
 
 try:
     from telethon.errors.rpcerrorlist import ApiIdInvalidError, PhoneNumberInvalidError
@@ -9,7 +17,7 @@ try:
     print("Found an existing installation of Telethon...\nSuccessfully Imported.")
 except ImportError:
     print("Installing Telethon...")
-    os.system(f"{executable} -m pip install telethon")
+    install_package("telethon")
     print("Done. Installed and imported Telethon.")
     from telethon.errors.rpcerrorlist import ApiIdInvalidError, PhoneNumberInvalidError
     from telethon.sessions import StringSession

--- a/utils/gensession.py
+++ b/utils/gensession.py
@@ -1,13 +1,19 @@
 import shutil
 import subprocess
+import sys
 from sys import executable
 
 
 def install_package(package: str):
     if shutil.which("uv"):
-        subprocess.call(["uv", "pip", "install", "--python", executable, package])
+        command = ["uv", "pip", "install", "--python", executable, package]
     else:
-        subprocess.call([executable, "-m", "pip", "install", package])
+        command = [executable, "-m", "pip", "install", package]
+    try:
+        subprocess.check_call(command)  # nosec B603 - command is built from a controlled allow-list
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to install {package}: {exc}")
+        sys.exit(exc.returncode or 1)
 
 try:
     from telethon.errors.rpcerrorlist import ApiIdInvalidError, PhoneNumberInvalidError

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -88,7 +88,9 @@ yum_python_check() {
         update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 >>/dev/null 2>&1
         PYV=$(which python3.6)
     fi
-    if command -v pip3 >>/dev/null 2>&1; then
+    if command -v uv >>/dev/null 2>&1; then
+        echo 'uv 存在 . . .'
+    elif command -v pip3 >>/dev/null 2>&1; then
         echo 'pip 存在 . . .'
     else
         echo "pip3 未安装在此系统上，正在进行安装"
@@ -165,7 +167,9 @@ apt_python_check() {
         update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 >>/dev/null 2>&1
         PYV=$(which python3.6)
     fi
-    if command -v pip3 >>/dev/null 2>&1; then
+    if command -v uv >>/dev/null 2>&1; then
+        echo 'uv 存在 . . .'
+    elif command -v pip3 >>/dev/null 2>&1; then
         echo 'pip 存在 . . .'
     else
         echo "pip3 未安装在此系统上，正在进行安装"
@@ -219,8 +223,10 @@ debian_python_check() {
         PYV=$(which python3)
         update-alternatives --install /usr/bin/python3 python3 $PYV 1 >>/dev/null 2>&1
     fi
-    echo "正在检查 pip3 安装情况 . . ."
-    if command -v pip3 >>/dev/null 2>&1; then
+    echo "正在检查 uv/pip3 安装情况 . . ."
+    if command -v uv >>/dev/null 2>&1; then
+        echo 'uv 存在 . . .'
+    elif command -v pip3 >>/dev/null 2>&1; then
         echo 'pip 存在 . . .'
     else
         echo "pip3 未安装在此系统上，正在进行安装"
@@ -260,9 +266,14 @@ download_repo() {
 
 pypi_install() {
     echo "下载安装 pypi 依赖中 . . ."
-    $PYV -m pip install --upgrade pip >>/dev/null 2>&1
-    $PYV -m pip install -r requirements.txt >>/dev/null 2>&1
-    sudo -H $PYV -m pip install --ignore-installed PyYAML >>/dev/null 2>&1
+    if command -v uv >>/dev/null 2>&1; then
+        uv pip install --python "$PYV" -r requirements.txt >>/dev/null 2>&1
+        uv pip install --python "$PYV" --reinstall PyYAML >>/dev/null 2>&1
+    else
+        $PYV -m pip install --upgrade pip >>/dev/null 2>&1
+        $PYV -m pip install -r requirements.txt >>/dev/null 2>&1
+        sudo -H $PYV -m pip install --ignore-installed PyYAML >>/dev/null 2>&1
+    fi
 }
 
 configure() {


### PR DESCRIPTION
Prefer `uv` when installing Python dependencies, with automatic fallback to `pip` when `uv` is unavailable.

  Changes include:

  - Add a shared package installation helper that uses `uv pip install --python ...` first and falls back to `python -m pip install`
  - Use the helper for runtime dependency updates and plugin-triggered package installation
  - Update `gensession.py` to prefer `uv` when installing Telethon
  - Update `utils/install.sh` to skip mandatory pip installation when `uv` is available
  - Update Dockerfiles to copy the standalone `uv` binary from `ghcr.io/astral-sh/uv` and install dependencies via `uv pip install --system`
  - Refresh related documentation text

  ## Motivation

  The project already contains `pyproject.toml`, `uv.lock`, and a `requirements.txt` generated by `uv export`. Using `uv` for installation can speed up clean installs, Docker builds, and dependency refreshes while keeping compatibility for environments that only have `pip`.

## Summary by Sourcery

Prefer uv for Python dependency installation while maintaining pip as a fallback across runtime, Docker, and installation workflows.

New Features:
- Introduce a shared helper module to build and run Python package installation commands that prefer uv and fall back to pip.

Enhancements:
- Update runtime dependency update logic and plugin-triggered package installation to use the shared uv-first package installation helper.
- Adjust system install script checks and dependency installation to prefer uv when available and only require pip when uv is absent.
- Update Docker images to include the uv binary and install Python dependencies via uv where possible.
- Change Telethon session generator to automatically install Telethon using uv when available, falling back to pip.

Documentation:
- Refresh README and Docker usage documentation to describe the new uv-first Python dependency installation behavior.